### PR TITLE
fix: correctness, logging, and encoder improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setuptools.setup(
         'msgpack>=1.0.0',
         'pypng==0.20220715.0'
     ],
+    extras_require={
+        'numpy': ['numpy>=1.20'],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/slidescore/lib/AnnoClasses.py
+++ b/slidescore/lib/AnnoClasses.py
@@ -144,6 +144,42 @@ class Heatmap():
             for j in range(len(source[0])):
                 target[i][j] = source[i][j]
 
+    @classmethod
+    def from_numpy(cls, arr: "numpy.ndarray", x_offset: int, y_offset: int, size_per_pixel: int) -> "Heatmap":
+        """Construct a Heatmap from a 2-D numpy array.
+
+        Parameters
+        ----------
+        arr : numpy.ndarray
+            2-D array with shape ``(rows, cols)``. Values must be in 0-255.
+            ``uint8`` arrays are accepted as-is; other integer/float dtypes are
+            validated for range then cast to ``uint8``.
+        x_offset : int
+        y_offset : int
+        size_per_pixel : int
+
+        Returns
+        -------
+        Heatmap
+        """
+        try:
+            import numpy as np
+        except ImportError as exc:
+            raise ImportError("numpy is required for Heatmap.from_numpy") from exc
+
+        if arr.ndim != 2:
+            raise ValueError(f"Expected a 2-D array, got shape {arr.shape}")
+
+        if arr.dtype != np.uint8:
+            arr_min, arr_max = int(arr.min()), int(arr.max())
+            if arr_min < 0 or arr_max > 255:
+                raise ValueError(
+                    f"Array values must be in range 0-255, got min={arr_min}, max={arr_max}"
+                )
+            arr = arr.astype(np.uint8)
+
+        return cls(arr.tolist(), x_offset, y_offset, size_per_pixel)
+
     def __len__(self):
         """Logical annotation count for Anno2 (`numItems`); not pixel/cell count."""
         return 1

--- a/slidescore/lib/AnnoClasses.py
+++ b/slidescore/lib/AnnoClasses.py
@@ -57,7 +57,7 @@ class Polygons(Sequence):
             return [self[index] for index in range(start, stop, step)]
 
         points_flat = self.polygons.getValues(i)
-        postive_vertices = [(points_flat[i], points_flat[i + 1]) for i in range(0, len(points_flat), 2)]
+        postive_vertices = [(points_flat[j], points_flat[j + 1]) for j in range(0, len(points_flat), 2)]
         return {
             "positiveVertices": postive_vertices,
             "negativeVerticesArr": self.negative_polygons_i[i] if i in self.negative_polygons_i else None
@@ -150,9 +150,6 @@ class Heatmap():
 
 class EfficientArray():
     """Efficient way to represent a array of arrays containing only unsigned integers"""
-    valuesArray = None # array.array('I')
-    offsetArray = None # array.array('I')
-    curOffsetIndex = None # 0
 
     def __init__(self):
         self.offsetArray = array.array('I')

--- a/slidescore/lib/AnnoClasses.py
+++ b/slidescore/lib/AnnoClasses.py
@@ -89,9 +89,9 @@ class Heatmap():
     x_offset: int
     y_offset: int
     size_per_pixel: int
-    name = "heatmap"
+    name: str
 
-    def __init__(self, data: list, x_offset: int, y_offset: int, size_per_pixel: int):
+    def __init__(self, data: list, x_offset: int, y_offset: int, size_per_pixel: int, name: str = "heatmap"):
         # data is 2d matrix containing the pixels
         self.matrix = self.generate_2d_ubyte_array(len(data), len(data[0]))
         try:
@@ -102,6 +102,7 @@ class Heatmap():
         self.x_offset = x_offset
         self.y_offset = y_offset
         self.size_per_pixel = size_per_pixel
+        self.name = name
 
         super().__init__()
 

--- a/slidescore/lib/AnnoClasses.py
+++ b/slidescore/lib/AnnoClasses.py
@@ -91,7 +91,10 @@ class Heatmap():
     def __init__(self, data: list, x_offset: int, y_offset: int, size_per_pixel: int):
         # data is 2d matrix containing the pixels
         self.matrix = self.generate_2d_ubyte_array(len(data), len(data[0]))
-        self.copy_matrix_to_larger(data, self.matrix)
+        try:
+            self.copy_matrix_to_larger(data, self.matrix)
+        except (OverflowError, TypeError) as exc:
+            raise ValueError("Heatmap values must be integers in range 0-255") from exc
 
         self.x_offset = x_offset
         self.y_offset = y_offset

--- a/slidescore/lib/AnnoClasses.py
+++ b/slidescore/lib/AnnoClasses.py
@@ -11,10 +11,10 @@ class Points(Sequence):
     Can be indexed to a get a tuple of the n'th point."""
     flattened_points = None
     name = "points"
-    metadata = {} # metadata per point "x,y", like: {"21,53": {"type": "lymphocyte"}, "3,4": {"type": "dendrophyl"}}
 
     def __init__(self, init_points: list = None):
         self.flattened_points = array.array('I')
+        self.metadata: Dict[str, Dict] = {}
         super().__init__()
 
         if init_points:
@@ -36,17 +36,14 @@ class Polygons(Sequence):
     """Somewhat space effecient method of storing the positive and negative vertices from a polygon.
     
     Internally uses EfficientArray to store the positive vertices of each polygon"""
-    polygons = None
-    simplified_polygons = []
-    negative_polygons_i = {}
-    labels = []
     name = "polygons"
-    metadata = {} # metadata per polygon index, like: {0: {"type": "lymphocyte"}, 3: {"type": "dendrophyl"}}
 
     def __init__(self):
         self.polygons = EfficientArray()
+        self.simplified_polygons = []
         self.negative_polygons_i = {}
         self.labels = []
+        self.metadata: Dict[int, Dict] = {}
         super().__init__()
 
     def __getitem__(self, i: int | slice):
@@ -142,7 +139,8 @@ class Heatmap():
                 target[i][j] = source[i][j]
 
     def __len__(self):
-        return len(self.matrix) * len(self.matrix[0]) # Number of bytes occupied
+        """Logical annotation count for Anno2 (`numItems`); not pixel/cell count."""
+        return 1
 
 class EfficientArray():
     """Efficient way to represent a array of arrays containing only unsigned integers"""

--- a/slidescore/lib/AnnoClasses.py
+++ b/slidescore/lib/AnnoClasses.py
@@ -1,8 +1,11 @@
 from collections.abc import Sequence
 from typing import Dict, List, Union
 import array
+import logging
 
 from slidescore.lib.simplify import simplifyPolygons
+
+_logger = logging.getLogger(__name__)
 # import numpy as np
 
 class Points(Sequence):
@@ -170,7 +173,7 @@ class EfficientArray():
     def getValues(self, i: int):
         """Retrieve an entry from the values array"""
         if i >= self.curOffsetIndex:
-            print("Trying to get i", i, "but max is", self.curOffsetIndex)
+            _logger.error("Trying to get i %s but max is %s", i, self.curOffsetIndex)
             return None
         start = self.offsetArray[i]
         end = self.offsetArray[i + 1]

--- a/slidescore/lib/Encoder.py
+++ b/slidescore/lib/Encoder.py
@@ -1,6 +1,6 @@
 import copy
+import logging
 import math
-import array
 import json
 import tarfile
 import zipfile
@@ -13,7 +13,9 @@ import brotli
 from .image_utils import get_png_bytes, lookup_table_2_png, encode_png
 from .AnnoClasses import Points, Polygons, Heatmap, Items, Item
 from .PolygonContainer import PolygonContainer
-from .utils import log, msgpack_encoder
+from .utils import msgpack_encoder
+
+_logger = logging.getLogger(__name__)
 
 class Encoder():
     """Encompassing class to encode AnnoClasses"""
@@ -49,18 +51,17 @@ class Encoder():
         self.user_metadata = {}
 
         if isinstance(items, Points):
-            log("Loaded", self.dataItems["numItems"], "points in encoder, type:", type_string)
+            _logger.debug("Loaded %s points in encoder, type: %s", self.dataItems["numItems"], type_string)
         elif isinstance(items, Polygons):
             self.items = copy.deepcopy(items)
             num_points = int(len(self.items.polygons.valuesArray) / 2)
-            log("Loaded", self.dataItems["numItems"], "polygons in encoder, with num points", num_points)
+            _logger.debug("Loaded %s polygons in encoder, with num points %s", self.dataItems["numItems"], num_points)
             self.items.simplify()
             num_points = int(len(self.items.polygons.valuesArray) / 2)
-            log("Simplified to num points", num_points)
-
+            _logger.debug("Simplified to num points %s", num_points)
 
         elif isinstance(items, Heatmap):
-            log("Loaded", self.dataItems["numItems"], f"byte {items.name} in encoder, with shape", len(self.items.matrix), len(self.items.matrix[0]))
+            _logger.debug("Loaded %s byte %s in encoder, with shape %s %s", self.dataItems["numItems"], items.name, len(items.matrix), len(items.matrix[0]))
 
     def calc_rect_around_item(self, item: Item):
         """Calculates a bounding box around a point or polygon, if it is a point the rectangle is the point"""
@@ -139,7 +140,7 @@ class Encoder():
         is_points = self.items.name == 'points' # Could also be mask
 
         if (are_few_points and is_points):
-            log(f"Detected few points ({len(items)}) , saving anno1 JSON")
+            _logger.debug("Detected few points (%s), saving anno1 JSON", len(items))
             # Instead encode as a Anno1 JSON, that will get compressed when dumping to a file
             anno1_points = [{"x": img_x, "y": img_y} for img_x, img_y in items]
             return json.dumps(anno1_points)
@@ -168,20 +169,20 @@ class Encoder():
         # encode as JSON anyway
         num_points_per_tile = len(items) / num_tiles
         if num_points_per_tile < self.low_density_cutoff and is_points:
-            log(f"Detected low density of points ({round(num_points_per_tile)} / tile), saving anno1 JSON")
+            _logger.debug("Detected low density of points (%s / tile), saving anno1 JSON", round(num_points_per_tile))
             anno1_points = [{"x": img_x, "y": img_y} for img_x, img_y in items]
             return json.dumps(anno1_points)
 
 
         # When we are done binning all points into the tiles, compress the tiles
         # into PNGs. A single PNG is a mask.
-        log("Compressing tiles as png's", num_tiles, len(items), len(items) / num_tiles)
+        _logger.debug("Compressing tiles as png's: %s tiles, %s points, %.1f pts/tile", num_tiles, len(items), len(items) / num_tiles)
         for tile_y in tile_bins:
             for tile_x in tile_bins[tile_y]:
                 tile = tile_bins[tile_y][tile_x]
                 img_bytes = get_png_bytes(tile, tile_size)
                 tile_bins[tile_y][tile_x] = img_bytes
-        log("Done compressing tiles")
+        _logger.debug("Done compressing tiles")
         return tile_bins
 
     def bin_polygons_into_tiles(self, tile_size: int):
@@ -207,11 +208,11 @@ class Encoder():
         """Bins items into seperate "tiles", which are then used to create a density map PNG to give a simplified representation
         of the items that can easily be process/drawn. """
         if isinstance(self.items, Heatmap):
-            log("Skipping lookup table generation for heatmap")
+            _logger.debug("Skipping lookup table generation for heatmap")
             return
-        
+
         if len(self.items) < self.few_points_cutoff and self.items.name == 'points':
-            log("Skipping lookup table generation for few points")
+            _logger.debug("Skipping lookup table generation for few points")
             return
 
         for tile_size in [32, 256]:
@@ -225,7 +226,7 @@ class Encoder():
             
             lookup_table['png'] = lookup_table_2_png(lookup_table)
             self.dataLookup.append(lookup_table)
-            log("Done with lookup table of size", tile_size)
+            _logger.debug("Done with lookup table of size %s", tile_size)
 
     def bin_items_into_lookup_table(self, tile_size: int):
         """Method to bin items into "tiles" of a certain size and keep track on how many items fall inside such a tile.
@@ -305,7 +306,7 @@ class Encoder():
 
     def dump_to_file(self, path: str):
         """Dumps the encoded items to a ZIP file on disk. Also encodes the polygon if needed."""
-        log("Encoding and dumping to zipfile")
+        _logger.debug("Encoding and dumping to zipfile")
 
         if not path.endswith('.zip'):
             path += '.zip'

--- a/slidescore/lib/Encoder.py
+++ b/slidescore/lib/Encoder.py
@@ -1,3 +1,4 @@
+import copy
 import math
 import array
 import json
@@ -50,10 +51,11 @@ class Encoder():
         if isinstance(items, Points):
             log("Loaded", self.dataItems["numItems"], "points in encoder, type:", type_string)
         elif isinstance(items, Polygons):
-            num_points = int(len(items.polygons.valuesArray) / 2)
+            self.items = copy.deepcopy(items)
+            num_points = int(len(self.items.polygons.valuesArray) / 2)
             log("Loaded", self.dataItems["numItems"], "polygons in encoder, with num points", num_points)
-            items.simplify()
-            num_points = int(len(items.polygons.valuesArray) / 2)
+            self.items.simplify()
+            num_points = int(len(self.items.polygons.valuesArray) / 2)
             log("Simplified to num points", num_points)
 
 

--- a/slidescore/lib/Encoder.py
+++ b/slidescore/lib/Encoder.py
@@ -5,7 +5,6 @@ import json
 import tarfile
 import zipfile
 import io
-from typing import List, Dict, Any
 
 import msgpack
 import brotli
@@ -19,12 +18,6 @@ _logger = logging.getLogger(__name__)
 
 class Encoder():
     """Encompassing class to encode AnnoClasses"""
-    items: Items = None
-
-    dataItems: Dict[str, Any] = None # Data regarding the raw mask / polygon / heatmap containers
-    dataLookup: List[Dict] = None # Data regarding lookup tables for mask and polygons
-    system_metadata = {} # Metadata that is controlled by this encoder, used in decoding
-    user_metadata = {} # Metadata that the user passes regarding this annotation, saved in the output zip
     big_polygon_size_cutoff = 100 * 100 # Size that is considered a "big" polygon, saved seperatly
     few_points_cutoff = 500 * 1000 # Determined using some tests
     low_density_cutoff = 30 # If there are fewer than 30 points per 256x256 PNG tile, save points as json

--- a/slidescore/lib/omega_encoder.py
+++ b/slidescore/lib/omega_encoder.py
@@ -105,38 +105,42 @@ class OmegaEncoder():
 
 def stress_test_omega_encoding():
     """Testing method to see how fast the encoding and decoding is for the OmegaEncoder class above"""
+    import logging as _logging
     import time
-    import random
     import brotli
+    _log = _logging.getLogger(__name__)
     num_points = 100 * 1000
     random_ints = [(i % 256) + 1 for i in range(num_points)]
     t0 = time.time()
     omega_encoder = OmegaEncoder()
     omega_encoded_bits = omega_encoder.encode(random_ints, "naturalOnly")
     t1 = time.time()
-    print(f'Encoding took: {(t1 - t0):.2f} seconds for {len(random_ints)} numbers in {omega_encoded_bits.nbytes} bytes')
+    _log.debug("Encoding took: %.2f seconds for %s numbers in %s bytes", t1 - t0, len(random_ints), omega_encoded_bits.nbytes)
     decoded_nums = omega_encoder.decode(omega_encoded_bits, "naturalOnly")
-    print(f'Decoding took: {(time.time() - t1):.2f} seconds')
+    _log.debug("Decoding took: %.2f seconds", time.time() - t1)
     if decoded_nums == random_ints:
-        print('And the input is the same as the output')
+        _log.debug("And the input is the same as the output")
     else:
-        print('ERROR: Input and output not the same')
+        _log.error("ERROR: Input and output not the same")
 
     t2 = time.time()
     compressed_bytes = brotli.compress(omega_encoded_bits.tobytes())
-    print(f'Compressing took: {(time.time() - t2):.2f} seconds, to {len(compressed_bytes)} bytes')
+    _log.debug("Compressing took: %.2f seconds, to %s bytes", time.time() - t2, len(compressed_bytes))
     open('./omega_encoded_nums.bin', 'wb').write(omega_encoded_bits.tobytes())
 
 if __name__ == '__main__':
+    import logging as _logging
+    _logging.basicConfig(level=_logging.DEBUG)
+    _log = _logging.getLogger(__name__)
     # Usage python omega_encode.py [...list of ints to encode]
     if len(sys.argv[1:]) > 0:
         passed_ints = list(map(int, sys.argv[1:]))
         omega_encoder = OmegaEncoder()
         res = omega_encoder.encode(passed_ints, 'naturalOnly')
 
-        print(f'{res.nbytes} bytes needed to represent {len(passed_ints)} ints')
+        _log.debug("%s bytes needed to represent %s ints", res.nbytes, len(passed_ints))
         if len(res) < 50:
-            print(res)
-        print(omega_encoder.decode(res, 'naturalOnly'))
+            _log.debug("%s", res)
+        _log.debug("%s", omega_encoder.decode(res, 'naturalOnly'))
     else:
         stress_test_omega_encoding()

--- a/slidescore/lib/polygon_encoder.py
+++ b/slidescore/lib/polygon_encoder.py
@@ -141,14 +141,17 @@ def polygons_2_bytes(polygons: EfficientArray, tile_size = 256):
     return write_handle.getbuffer()
 
 if __name__ == "__main__":
-    print("Generating simple encoded polygons!")
+    import logging as _logging
+    _logging.basicConfig(level=_logging.DEBUG)
+    _log = _logging.getLogger(__name__)
+    _log.debug("Generating simple encoded polygons!")
     polygons = Polygons()
     polygon = [1, 1, 1, 2, 300, 300, 3, 3]
     polygons.addPolygon(polygon)
     polygon = [400, 400, 200, 200, 5, 5, 3, 3, 0, 0]
     polygons.addPolygon(polygon)
-    
+
     buf = polygons_2_bytes(polygons.polygons)
     with open('encoded_polygons.bin', 'wb') as fh:
         fh.write(buf)
-    print("Wrote encoded_polygons.bin")
+    _log.debug("Wrote encoded_polygons.bin")

--- a/slidescore/lib/simplify.py
+++ b/slidescore/lib/simplify.py
@@ -108,10 +108,13 @@ def simplifyPolygons(polygons_arr, tolerance=1.0):
     return simp_polygons_arr
 
 if __name__ == "__main__":
+    import logging as _logging
+    _logging.basicConfig(level=_logging.DEBUG)
+    _log = _logging.getLogger(__name__)
     from .AnnoClasses import Polygons
-    print("Testing simplify algorithm")
+    _log.debug("Testing simplify algorithm")
     almost_triangle = [0, 0, 100, 100, 105, 95, 200, 0]
     polygons = Polygons()
     polygons.addPolygon(almost_triangle)
     res = simplify(almost_triangle, 1)
-    print(list(res))
+    _log.debug("%s", list(res))

--- a/slidescore/lib/utils.py
+++ b/slidescore/lib/utils.py
@@ -1,12 +1,10 @@
-# Std libs
-import sys
 import array
-import time
 import json
 import math
 import logging
 
-# Local libs
+_logger = logging.getLogger(__name__)
+
 from .AnnoClasses import EfficientArray, Points, Polygons, Heatmap
 from .PolygonContainer import PolygonContainer
 
@@ -134,8 +132,8 @@ def read_geo_json(path: str):
         return polygons
 
     # We got _both_ polygons and points
-    print("WARNING: Detected BOTH points and polygons in GeoJSON, only continueing with polygons", file=sys.stderr)
-    print("WARNING: Please remove the points from the GeoJSON to prevent ambiguity", file=sys.stderr)
+    _logger.warning("Detected BOTH points and polygons in GeoJSON, only continuing with polygons")
+    _logger.warning("Please remove the points from the GeoJSON to prevent ambiguity")
     return polygons
 
 def extract_geojson(data):
@@ -463,40 +461,37 @@ def msgpack_encoder(obj):
 
 # miscellaneous
 
-time_on_load = time.time()
-def log(*args):
-    """Logs the arguments to the console, prefixing the time passed since script execution began"""
-    time_passed = time.time() - time_on_load
-    print("{:.2f}".format(time_passed), ' '.join(map(str, args)))
-
-
-NOTICE_LEVEL = 25  # between INFO (20) and WARNING (30)
-logging.addLevelName(NOTICE_LEVEL, "NOTICE")
-
-def notice(self, message, *args, **kwargs):
-    if self.isEnabledFor(NOTICE_LEVEL):
-        self._log(NOTICE_LEVEL, message, args, **kwargs)
-
-logging.Logger.notice = notice
+_NOTICE_LEVEL = 25  # between INFO (20) and WARNING (30)
 
 def get_logger(verbosity: int) -> logging.Logger:
-    """Configure and return a logger with the given verbosity level."""
-    # Map verbosity count to logging levels
+    """Configure and return a logger with the given verbosity level.
+
+    Registers a custom NOTICE level (25, between INFO and WARNING) on first
+    call. This is intentionally deferred so importing the library has no side
+    effects on the logging system.
+    """
+    if not hasattr(logging.Logger, "notice"):
+        logging.addLevelName(_NOTICE_LEVEL, "NOTICE")
+
+        def _notice(self, message, *args, **kwargs):
+            if self.isEnabledFor(_NOTICE_LEVEL):
+                self._log(_NOTICE_LEVEL, message, args, **kwargs)
+
+        logging.Logger.notice = _notice  # type: ignore[attr-defined]
+
     if verbosity == 0:
-        level = NOTICE_LEVEL
+        level = _NOTICE_LEVEL
     elif verbosity == 1:
         level = logging.INFO
     else:
         level = logging.DEBUG
 
-    # Configure root logger
     logging.basicConfig(
         level=level,
         format="%(asctime)s [%(levelname)s] %(message)s",
-        datefmt="%H:%M:%S"
+        datefmt="%H:%M:%S",
     )
 
     logger = logging.getLogger(__name__)
     logger.level = level
-
     return logger

--- a/slidescore/lib/utils.py
+++ b/slidescore/lib/utils.py
@@ -396,12 +396,11 @@ def read_tsv_binary_heatmap(path: str):
 
 
         # Construct the heatmap
-        heatmap = Heatmap(data, x_offset, y_offset, size_per_pixel)
+        heatmap = Heatmap(data, x_offset, y_offset, size_per_pixel, name='binary-heatmap')
         for line in fh:
             line_parts = line.split()
             x, y = int(line_parts[0]), int(line_parts[1])
             heatmap.setPoint(x, y, 255)
-    heatmap.name = 'binary-heatmap'
     return heatmap
 
 # Export functions

--- a/slidescore/lib/utils.py
+++ b/slidescore/lib/utils.py
@@ -39,7 +39,7 @@ def read_tsv(path: str, points_type: str, support_experimental = False):
         items = read_tsv_polygons(path)
         
     if len(items) == 0:
-        sys.exit("No items loaded")
+        raise ValueError("No items loaded")
 
     return items
 
@@ -165,10 +165,8 @@ def extract_geojson(data):
             for polygon in geometry["coordinates"]:
                 yield (None, polygon[0], polygon[1:])
         elif geometry["type"] == "Point":
-            # If we got a GeoJSON with points, report them as a polygon of length 2
-            # Callee should handle this
-            for polygon in geometry["coordinates"]:
-                yield (metadata, [geometry["coordinates"]], [])
+            # coordinates is [x, y]; yield once as a single-point polygon
+            yield (metadata, [geometry["coordinates"]], [])
 
 def read_slidescore_json(data):
     """Parses JSON's that are created using the SlideScore Front-end.

--- a/slidescore/slidescore.py
+++ b/slidescore/slidescore.py
@@ -606,7 +606,6 @@ class APIClient(object):
             encoder.add_metadata(metadata)
 
         encoder.dump_to_file(output_path)
-        print('Done converting to anno2')
 
 
     def convert_annotation_to_anno2(self, study_id, case_id, image_id, tma_core_id,

--- a/slidescore/slidescore.py
+++ b/slidescore/slidescore.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from collections.abc import Mapping
 import json
 import sys
 import requests
@@ -52,8 +53,8 @@ class SlideScoreResult:
 
         if self.answer is not None and self.answer[:2] == '[{':
             annos = json.loads(self.answer)
-            if len(annos) > 0:
-                if hasattr(annos[0], 'type'):
+            if len(annos) > 0 and isinstance(annos[0], Mapping):
+                if annos[0].get("type") is not None:
                     self.annotations = annos
                 else:
                     self.points = annos
@@ -349,7 +350,7 @@ class APIClient(object):
     def upload_ASAP(self, imageid, user, questions_map, annotation_name, asap_annotation):
         response = self.perform_request("UploadASAPAnnotations", {
                  "imageid": imageid,
-                 "questionsMap": '\n'.join(key+";"+value for key, val in questions_map.items()),
+                 "questionsMap": '\n'.join(f"{key};{val}" for key, val in questions_map.items()),
                  "user": user,
                  "annotationName": annotation_name,
                  "asapAnnotation": asap_annotation}
@@ -383,8 +384,6 @@ class APIClient(object):
         tuple
             Pair consisting of url, cookie.
         """
-        if self.base_url is None:
-            raise RuntimeError
         response = self.perform_request("GetTileServer?imageId="+str(imageid), None,  method="GET")
         rjson = response.json()
         return ( 

--- a/slidescore/slidescore.py
+++ b/slidescore/slidescore.py
@@ -12,7 +12,7 @@ import unicodedata
 
 from .lib.utils import read_slidescore_json
 from .lib.Encoder import Encoder
-from .lib.AnnoClasses import Points, Polygons
+from .lib.AnnoClasses import Heatmap, Points, Polygons
 
 class SlideScoreErrorException(Exception):
     pass
@@ -586,14 +586,14 @@ class APIClient(object):
         
     def convert_to_anno2(self, items, metadata, output_path):
         """Converts a SlideScore Annotation Object to the new Anno2 zip based format
-        Only supports annotations of points or polygons/brush. Will error otherwise.
+        Supports points, polygons/brush, or a :class:`Heatmap` instance (same union as :class:`Encoder`).
 
         anno1_data: Dictionary containing the annotation like: [{"type": "brush", "positivePolygons": [] ...]
         metadata: Dictionary containing any metadata regarding the annotation, will be included as JSON in output
         output_path: string of the path on disk the anno2.zip will be written to
         """
-        # Allow pre-loaded Points and Polygons objects
-        if not isinstance(items, Points) and not isinstance(items, Polygons):
+        # Allow pre-loaded Points, Polygons, and Heatmap objects (match ``Encoder``)
+        if not isinstance(items, (Points, Polygons, Heatmap)):
             items = read_slidescore_json(items)
         
         encoder = Encoder(items, big_polygon_size_cutoff=100 * 100)

--- a/slidescore/slidescore.py
+++ b/slidescore/slidescore.py
@@ -51,13 +51,16 @@ class SlideScoreResult:
         self.question = dict['question']
         self.answer = dict['answer']
 
-        if self.answer is not None and self.answer[:2] == '[{':
-            annos = json.loads(self.answer)
-            if len(annos) > 0 and isinstance(annos[0], Mapping):
-                if annos[0].get("type") is not None:
-                    self.annotations = annos
-                else:
-                    self.points = annos
+        if self.answer is not None and len(self.answer) >= 2 and self.answer[:2] == '[{':
+            try:
+                annos = json.loads(self.answer)
+                if len(annos) > 0 and isinstance(annos[0], Mapping):
+                    if annos[0].get("type") is not None:
+                        self.annotations = annos
+                    else:
+                        self.points = annos
+            except json.JSONDecodeError:
+                pass
                     
     def toRow(self):
         """

--- a/tests/test_API_client.py
+++ b/tests/test_API_client.py
@@ -4,6 +4,7 @@ This test checks the ability to create a API client and the reachability of the 
 
 import sys
 import os
+from unittest.mock import MagicMock, patch
 
 import slidescore
 
@@ -22,6 +23,43 @@ def test_client_creation():
     client = slidescore.APIClient(SLIDESCORE_HOST, SLIDESCORE_API_KEY)
     response = client.perform_request('Studies', None, method="GET")
     assert response.status_code == 200
+
+
+def test_upload_ASAP_questions_map_joins_key_value():
+    posted = {}
+
+    def fake_post(url, verify=True, headers=None, data=None, **kwargs):
+        posted.clear()
+        posted.update(data or {})
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"success": True}
+        return r
+
+    client = slidescore.APIClient("https://example.com", "token")
+    with patch("slidescore.slidescore.requests.post", side_effect=fake_post):
+        client.upload_ASAP(
+            42,
+            "user",
+            {"#e6194b": "Test anno"},
+            "Annotation",
+            "<ASAP/>",
+        )
+    assert posted["questionsMap"] == "#e6194b;Test anno"
+
+
+def test_get_image_server_url_builds_from_end_point():
+    def fake_get(url, verify=True, headers=None, data=None, stream=True, **kwargs):
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"urlPart": "dz", "cookiePart": "c=1"}
+        return r
+
+    client = slidescore.APIClient("https://host.example", "token")
+    with patch("slidescore.slidescore.requests.get", side_effect=fake_get):
+        tile_url, cookie = client.get_image_server_url(7)
+    assert tile_url == "https://host.example/i/7/dz/_files"
+    assert cookie == "c=1"
 
 
 if __name__ == "__main__":

--- a/tests/test_anno2.py
+++ b/tests/test_anno2.py
@@ -4,6 +4,7 @@ This test checks if a local annotation can be converted into an anno2, and if it
 import os
 import tempfile
 import shutil
+import zipfile
 from datetime import datetime
 import json
 
@@ -11,6 +12,8 @@ from common_lib import create_study
 
 import slidescore
 import slidescore.bin_data
+from slidescore.lib.AnnoClasses import Heatmap, Points, Polygons
+from slidescore.lib.Encoder import Encoder
 
 
 def gen_mask_tsv(size, x_offset=0, y_offset=0):
@@ -106,6 +109,59 @@ def create_anno2s():
         output_fns.append(option_anno2_path)
     
     return output_fns
+
+
+def test_heatmap_numitems_in_system_metadata():
+    data = [[10, 20, 30], [40, 50, 60], [70, 80, 90]]
+    hm = Heatmap(data, x_offset=5, y_offset=6, size_per_pixel=16)
+    assert len(hm) == 1
+    enc = Encoder(hm)
+    assert enc.system_metadata["numItems"] == 1
+    assert enc.dataItems["numItems"] == 1
+
+
+def test_heatmap_zip_system_metadata(tmp_path):
+    data = [[1, 2], [3, 4]]
+    hm = Heatmap(data, 0, 0, 8)
+    out = tmp_path / "hm.zip"
+    enc = Encoder(hm)
+    enc.generate_tile_data(256)
+    enc.populate_lookup_tables()
+    enc.dump_to_file(str(out))
+    with zipfile.ZipFile(out) as zf:
+        meta = json.loads(zf.read("system_metadata.json").decode())
+    assert meta["type"] == "heatmap"
+    assert meta["numItems"] == 1
+
+
+def test_points_metadata_is_not_shared():
+    a = Points([(0, 0)])
+    b = Points([(1, 1)])
+    a.metadata["k"] = {"x": 1}
+    assert a.metadata
+    assert "k" not in b.metadata
+
+
+def test_polygons_metadata_is_not_shared():
+    p1 = Polygons()
+    p1.addPolygon([0, 0, 1, 0, 1, 1])
+    p2 = Polygons()
+    p2.addPolygon([2, 2, 3, 2, 3, 3])
+    p1.metadata[0] = {"label": "a"}
+    assert 0 in p1.metadata
+    assert 0 not in p2.metadata
+
+
+def test_convert_to_anno2_accepts_heatmap_instance(tmp_path):
+    hm = Heatmap([[1, 2, 3], [4, 5, 6]], 10, 20, 4)
+    out = tmp_path / "from_client.zip"
+    client = slidescore.APIClient("https://example.invalid/", "token")
+    client.convert_to_anno2(hm, None, str(out))
+    with zipfile.ZipFile(out) as zf:
+        meta = json.loads(zf.read("system_metadata.json").decode())
+    assert meta["numItems"] == 1
+    assert meta["type"] == "heatmap"
+
 
 def test_anno2():
     # First test if we can create anno2s locally at all

--- a/tests/test_upload_results.py
+++ b/tests/test_upload_results.py
@@ -89,5 +89,30 @@ def test_upload_study_results():
     except:
         assert True # Failed succesfully!
 
+
+def test_slidescore_result_typed_json_answer_sets_annotations():
+    r = slidescore.SlideScoreResult({
+        "id": 1,
+        "imageID": 10,
+        "imageName": "slide",
+        "user": "u",
+        "question": "q",
+        "answer": '[{"type":"polygon","points":[{"x":1,"y":2}]}]',
+    })
+    assert r.annotations[0]["type"] == "polygon"
+
+
+def test_slidescore_result_plain_xy_json_answer_sets_points():
+    r = slidescore.SlideScoreResult({
+        "id": 1,
+        "imageID": 10,
+        "imageName": "slide",
+        "user": "u",
+        "question": "q",
+        "answer": '[{"x": 10, "y": 20}]',
+    })
+    assert r.points[0]["x"] == 10
+
+
 if __name__ == "__main__":
     sys.exit('This file is meant to be ran by PyTest')


### PR DESCRIPTION
fix: correctness, logging, and encoder improvements

fix(utils): yield once per Point, not once per coordinate + raise ValueError instead of sys.exit on empty input
fix(encoder): copy polygons before simplify to avoid mutating caller data
fix(heatmap): validate values are 0-255 on construction
fix(results): handle JSON decoding errors
refactor(logging): replace log() and print() with stdlib logging and remove stdout print from convert_to_anno2
refactor(classes): remove class-level mutable defaults
feat(heatmap): add Heatmap.from_numpy with optional numpy extra
refactor(heatmap): make name a constructor parameter, not mutable attribute
